### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # RabbitMQ JMS Client Demo on Spring Boot
 
-This sample application demonstrates the [Rabbit JMS connector](http://blog.gopivotal.com/products/messaging-with-jms-and-rabbitmq) by producing and consuming stock quotes.
+This sample application demonstrates the [Rabbit JMS connector](https://content.pivotal.io/blog) by producing and consuming stock quotes.
 
 ## Prerequisites 
 
-To use it, you need to have RabbitMQ [installed](http://www.rabbitmq.com/download.html) and running
+To use it, you need to have RabbitMQ [installed](https://www.rabbitmq.com/download.html) and running
 with the [JMS topic exchange plugin](https://github.com/rabbitmq/rabbitmq-jms-topic-exchange).
 
 Assuming RabbitMQ is running in a local terminal:
@@ -13,7 +13,7 @@ Assuming RabbitMQ is running in a local terminal:
 $ rabbitmq-server
 
               RabbitMQ *.*.*. Copyright (C) 2007-2016 Pivotal Software, Inc.
-  ##  ##      Licensed under the MPL.  See http://www.rabbitmq.com/
+  ##  ##      Licensed under the MPL.  See https://www.rabbitmq.com/
   ##  ##
   ##########  Logs: /usr/local/var/log/rabbitmq/rabbit@localhost.log
   ######  ##        /usr/local/var/log/rabbitmq/rabbit@localhost-sasl.log
@@ -25,7 +25,7 @@ $ rabbitmq-server
 
 ## Getting started… fast!
 
-One of the fastest ways to get this demo going is using [Spring Boot's CLI](http://docs.spring.io/spring-boot/docs/current/reference/html/getting-started-installing-spring-boot.html).
+One of the fastest ways to get this demo going is using [Spring Boot's CLI](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started-installing-spring-boot.html).
 
 With Spring Boot CLI in `PATH`, run both parts of the demo with
 

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -96,7 +96,7 @@ Apache Geronimo
 Copyright 2003-2008 The Apache Software Foundation
 
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 
 --------------- SECTION 3: Mozilla Public License, V1.1 ----------
@@ -109,7 +109,7 @@ Mozilla Public License, V1.1 is applicable to the following component(s).
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -155,7 +155,7 @@ amqp-client-3.5.6-sources.jar\com\rabbitmq\client\impl\VariableLinkedBlockingQue
  */
 * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 
@@ -806,7 +806,7 @@ EXHIBIT A -Mozilla Public License.
    Version 1.1 (the "License"); you may not use this file except in
    compliance with the License. You may obtain a copy of the License at
 
-   http://www.mozilla.org/MPL/
+   https://www.mozilla.org/MPL/
 
    Software distributed under the License is distributed on an "AS IS"
    basis, WITHOUT WARRANTY OF
@@ -852,7 +852,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from Pivotal's website at
-http://www.pivotal.io/open-source, or by sending a request, 
+https://www.pivotal.io/open-source, or by sending a request, 
 with your name and address to: Pivotal Software, Inc., 3496 Deer Creek Rd, 
 Palo Alto, CA 94304, Attention: General Counsel. All such requests should 
 clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://blog.gopivotal.com/products/messaging-with-jms-and-rabbitmq (301) with 1 occurrences migrated to:  
  https://content.pivotal.io/blog ([https](https://blog.gopivotal.com/products/messaging-with-jms-and-rabbitmq) result SSLHandshakeException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.spring.io/spring-boot/docs/current/reference/html/getting-started-installing-spring-boot.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started-installing-spring-boot.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started-installing-spring-boot.html) result 200).
* http://www.apache.org/ with 1 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* http://www.rabbitmq.com/download.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/download.html ([https](https://www.rabbitmq.com/download.html) result 200).
* http://www.mozilla.org/MPL/ with 3 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* http://www.pivotal.io/open-source with 1 occurrences migrated to:  
  https://www.pivotal.io/open-source ([https](https://www.pivotal.io/open-source) result 301).
* http://creativecommons.org/licenses/publicdomain with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/publicdomain ([https](https://creativecommons.org/licenses/publicdomain) result 302).